### PR TITLE
Feat(#41) fix header and footer

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -3,5 +3,5 @@
 <main class="main">
   <router-outlet></router-outlet>
 </main>
-<footer app-footer></footer>
+<footer app-footer *ngIf="footerVisibility"></footer>
 

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -15,6 +15,8 @@
 
   display: flex;
   flex-flow: column;
+  justify-content: space-between;
+  flex-grow: 1;
   &::-webkit-scrollbar {
     -webkit-appearance: none;
     width: 5px;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,8 +1,28 @@
 import { Component } from '@angular/core';
+import { NavigationStart, Router } from '@angular/router';
+import { ParamKey } from './app-routing.enum';
 
 @Component({
   selector: 'body[app-root]',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
 })
-export default class AppComponent {}
+export default class AppComponent {
+  footerVisibility = true;
+  constructor(private router: Router) {
+    this.router.events.subscribe((val) => {
+      if (val instanceof NavigationStart) {
+        if (
+          val.url.includes(ParamKey.audiocallPromo) ||
+          val.url.includes(ParamKey.savannaPromo) ||
+          val.url.includes('audiocall') ||
+          val.url.includes('audiocall')
+        ) {
+          this.footerVisibility = false;
+        } else {
+          this.footerVisibility = true;
+        }
+      }
+    });
+  }
+}

--- a/src/app/pages/games/audiocall-game/components/audiocall-promo/audiocall-promo.component.ts
+++ b/src/app/pages/games/audiocall-game/components/audiocall-promo/audiocall-promo.component.ts
@@ -18,12 +18,11 @@ export class AudiocallPromoComponent implements OnInit {
   ngOnInit(): void {
     this.route.queryParams.subscribe((param) => {
       this.startFromMenu = param.startFromMenu;
-      if (this.startFromMenu === "true") {
+      if (this.startFromMenu === 'true') {
         this.startFromMenu = true;
       } else {
         this.startFromMenu = false;
       }
     });
-    console.log(typeof this.startFromMenu);
   }
 }

--- a/src/app/shared/layout/header/header.component.scss
+++ b/src/app/shared/layout/header/header.component.scss
@@ -3,7 +3,6 @@
 
 :host {
   display: flex;
-  margin-right: auto;
   @include media-max-width {
     @include main-header-grid;
     height: 20vh;

--- a/src/scss/common.scss
+++ b/src/scss/common.scss
@@ -1,9 +1,11 @@
 @import url('https://fonts.googleapis.com/css2?family=Lato&family=Montserrat&family=Open+Sans&family=Roboto&family=Roboto+Condensed&family=Source+Sans+Pro&display=swap');
 
 body {
+  display: flex;
+  height: 100vh;
+  flex-direction: column;
   font-family: $font-main;
   color: $main-text-color;
-  height: 100%;
 }
 
 a {


### PR DESCRIPTION
1. Поправил стили. Теперь нет "пустого места" под footer.
2. Написал логику для того, чтобы "прятать" footer  в играх.
![for-footer](https://user-images.githubusercontent.com/55794636/114228828-b286b100-997f-11eb-832c-27a45a7a7bbd.png)
Вместо 'audiocall' по анологии свои пути к играм впишите Юля и Костя.